### PR TITLE
Java 11 support

### DIFF
--- a/callout/pom.xml
+++ b/callout/pom.xml
@@ -18,6 +18,7 @@
     <bouncycastle.version>1.64</bouncycastle.version>
     <jackson.version>[2.9.10.1,)</jackson.version>
     <apiproxy.java.rsrc.dir>../bundle/apiproxy/resources/java</apiproxy.java.rsrc.dir>
+    <jaxb.version>2.3.0</jaxb.version>
   </properties>
 
   <dependencies>
@@ -74,6 +75,17 @@ do it manually by running these commands:
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>${slf4j.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <version>${jaxb.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+      <version>${jaxb.version}</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Able to compile in Java 11 after added jaxb libraries, but facing issues in test cases due to `JMockit`.

JMockit `Startup` class has configuration till `Java 8`, above any version it will be considering as below `JDK 6`. Please refer the screen shot.

<img width="914" alt="image" src="https://user-images.githubusercontent.com/5071333/130505144-c6746514-c46f-41f3-9c0a-b06c1ac136c8.png">

May be required some good amount of changes to migrate from `com.googlecode.jmockit` library to `org.jmockit`.

Able to validate the build locally by skipping the test cases `mvn clean package -DskipTests`.